### PR TITLE
Add more details about modern feature being used

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 This is a fork of the popular [`delegate`](https://github.com/zenorocha/delegate) with some improvements:
 
-- modern: ES6, TypeScript, Edge 15+ (it uses `WeakMap` and `Element.closest()`)
+- modern: ES6, TypeScript, Edge 15+ (it uses `WeakMap`, `Element.closest()` and the `EventTarget` constructor to detect nodes)
 - idempotent: identical listeners aren't added multiple times, just like the native `addEventListener`
 - debugged ([2d54c11](https://github.com/bfred-it/delegate-it/commit/2d54c1182aefd3ec9d8250fda76290971f5d7166), [c6bb88c](https://github.com/bfred-it/delegate-it/commit/c6bb88c2aa8097b25f22993a237cf09c96bcbfb8))
 


### PR DESCRIPTION
Distinguishing the different signature now relies on the `EventTarget` constructor to check the instance. While WeakMap and `Element.closest()` can be polyfilled in IE 11, HTML elements being instance of the `EventTarget` constructor cannot, so this is the biggest blocker for compatibility.