### PR TITLE
Add support for `AddEventListenerOptions` deduplication

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,1 @@
+declare module 'many-keys-map';

--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,12 @@
+import mem from 'mem';
+import ManyKeysMap from 'many-keys-map';
+
 namespace delegate {
 	export type EventType = keyof GlobalEventHandlersEventMap;
 
 	export type DelegateSubscription = {
 		destroy: VoidFunction;
 	};
-
-	export type Setup = {
-		selector: string;
-		type: EventType;
-		useCapture?: boolean | AddEventListenerOptions;
-	}
 
 	export type DelegateEventHandler<TEvent extends Event = Event, TElement extends Element = Element> = (event: DelegateEvent<TEvent, TElement>) => void;
 
@@ -18,7 +15,24 @@ namespace delegate {
 	}
 }
 
-const elements = new WeakMap<EventTarget, WeakMap<delegate.DelegateEventHandler<any, any>, Set<delegate.Setup>>>();
+const getDelegateListener = mem(<TElement extends Element = Element, TEvent extends Event = Event>(
+	selector: string,
+	callback: delegate.DelegateEventHandler<TEvent, TElement>
+) => (event: Partial<delegate.DelegateEvent>): void => {
+	const delegateTarget = (event.target as Element).closest(selector) as TElement;
+	if (!delegateTarget) {
+		return;
+	}
+
+	// Closest may match elements outside of the currentTarget so it needs to be limited to elements inside it
+	if ((event.currentTarget as Element).contains(delegateTarget)) {
+		event.delegateTarget = delegateTarget;
+		callback.call(delegateTarget, event as delegate.DelegateEvent<TEvent, TElement>);
+	}
+}, {
+	cache: new ManyKeysMap(), // TODO: switch to `many-keys-weakmap` after https://github.com/bfred-it/many-keys-weakmap/pull/1
+	cacheKey: (...arguments_) => arguments_
+});
 
 function _delegate<TElement extends Element = Element, TEvent extends Event = Event>(
 	element: EventTarget,
@@ -27,82 +41,14 @@ function _delegate<TElement extends Element = Element, TEvent extends Event = Ev
 	callback: delegate.DelegateEventHandler<TEvent, TElement>,
 	useCapture?: boolean | AddEventListenerOptions
 ): delegate.DelegateSubscription {
-	const listenerFn: EventListener = (event: Partial<delegate.DelegateEvent>): void => {
-		const delegateTarget = (event.target as Element).closest(selector) as TElement;
+	const listener = getDelegateListener<TElement, TEvent>(selector, callback);
+	element.addEventListener(type, listener, useCapture);
 
-		if (!delegateTarget) {
-			return;
-		}
-
-		event.delegateTarget = delegateTarget;
-
-		// Closest may match elements outside of the currentTarget
-		// so it needs to be limited to elements inside it
-		if ((event.currentTarget as Element).contains(event.delegateTarget)) {
-			callback.call(element, event as delegate.DelegateEvent<TEvent, TElement>);
-		}
-	};
-
-	const delegateSubscription = {
+	return {
 		destroy() {
-			element.removeEventListener(type, listenerFn, useCapture);
-			if (!elements.has(element)) {
-				return;
-			}
-
-			const elementMap = elements.get(element)!;
-			if (!elementMap.has(callback)) {
-				return;
-			}
-
-			const setups = elementMap.get(callback);
-
-			if (!setups) {
-				return;
-			}
-
-			for (const setup of setups) {
-				if (
-					setup.selector !== selector ||
-					setup.type !== type ||
-					setup.useCapture === useCapture
-				) {
-					continue;
-				}
-
-				setups.delete(setup);
-				if (setups.size === 0) {
-					elementMap.delete(callback);
-				}
-
-				return;
-			}
+			element.removeEventListener(type, listener, useCapture);
 		}
 	};
-
-	const elementMap = elements.get(element) || new WeakMap<delegate.DelegateEventHandler<TEvent, TElement>, Set<delegate.Setup>>();
-	const setups = elementMap.get(callback) || new Set<delegate.Setup>();
-	for (const setup of setups) {
-		if (
-			setup.selector === selector &&
-			setup.type === type &&
-			setup.useCapture === useCapture
-		) {
-			return delegateSubscription;
-		}
-	}
-
-	// Remember event in tree
-	elements.set(element,
-		elementMap.set(callback,
-			setups.add({selector, type, useCapture})
-		)
-	);
-
-	// Add event on delegate
-	element.addEventListener(type, listenerFn, useCapture);
-
-	return delegateSubscription;
 }
 
 // No base element specified, defaults to `document`

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,8 @@ namespace delegate {
 	}
 }
 
-const getDelegateListener = mem(<TElement extends Element = Element, TEvent extends Event = Event>(
+// `mem` ensures that there's only ever 1 handler per `DelegateEventHandler + selector` callback, so the same DelegateEventHandler can't be attached twice
+const getDelegatingHandler = mem(<TElement extends Element = Element, TEvent extends Event = Event>(
 	selector: string,
 	callback: delegate.DelegateEventHandler<TEvent, TElement>
 ) => (event: Partial<delegate.DelegateEvent>): void => {
@@ -41,12 +42,12 @@ function _delegate<TElement extends Element = Element, TEvent extends Event = Ev
 	callback: delegate.DelegateEventHandler<TEvent, TElement>,
 	useCapture?: boolean | AddEventListenerOptions
 ): delegate.DelegateSubscription {
-	const listener = getDelegateListener<TElement, TEvent>(selector, callback);
-	element.addEventListener(type, listener, useCapture);
+	const handler = getDelegatingHandler<TElement, TEvent>(selector, callback);
+	element.addEventListener(type, handler, useCapture);
 
 	return {
 		destroy() {
-			element.removeEventListener(type, listener, useCapture);
+			element.removeEventListener(type, handler, useCapture);
 		}
 	};
 }

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ namespace delegate {
 	export type EventType = keyof GlobalEventHandlersEventMap;
 
 	export type DelegateSubscription = {
-		destroy: VoidFunction;
+		remove: VoidFunction;
 	};
 
 	export type DelegateEventHandler<TEvent extends Event = Event, TElement extends Element = Element> = (event: DelegateEvent<TEvent, TElement>) => void;
@@ -46,7 +46,7 @@ function _delegate<TElement extends Element = Element, TEvent extends Event = Ev
 	element.addEventListener(type, handler, useCapture);
 
 	return {
-		destroy() {
+		remove() {
 			element.removeEventListener(type, handler, useCapture);
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"prepare": "tsc",
 		"build": "tsc",
 		"_watch-build": "tsc --watch",
-		"_watch-test": "ava --watch",
+		"_watch-test": "ava --watch --verbose",
 		"watch": "run-p --silent _watch-*"
 	},
 	"xo": {
@@ -47,5 +47,9 @@
 			"@typescript-eslint/promise-function-async": 0,
 			"@typescript-eslint/no-namespace": 0
 		}
+	},
+	"dependencies": {
+		"many-keys-map": "^1.0.2",
+		"mem": "^4.3.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ const delegation = delegate(document.body, '.btn', 'click', event => {
     console.log(event.delegateTarget);
 });
 
-delegation.destroy();
+delegation.remove();
 ```
 
 #### With multiple elements (via selector or array)
@@ -88,7 +88,7 @@ const delegations = delegate('.container', '.btn', 'click', event => {
 });
 
 delegations.forEach(function (delegation) {
-    delegation.destroy();
+    delegation.remove();
 });
 ```
 

--- a/test.js
+++ b/test.js
@@ -20,23 +20,18 @@ global.document = window.document;
 const container = window.document.querySelector('ul');
 const anchor = window.document.querySelector('a');
 
-test.cb('should add an event listener', t => {
-	delegate(container, 'a', 'click', () => {
-		t.end();
-	});
+test('should add an event listener', t => {
+	delegate(container, 'a', 'click', t.pass);
 	anchor.click();
 });
 
-test.cb('should add an event listener only once', t => {
-	const handler = () => {
-		t.end();
-	};
+test('should add an event listener only once', t => {
+	t.plan(2);
 
-	const first = delegate(container, 'a', 'click', handler);
-	const second = delegate(container, 'a', 'click', handler);
+	delegate(container, 'a', 'click', t.pass, {passive: true});
+	delegate(container, 'a', 'click', t.pass, {passive: true});
+	delegate(container, 'a', 'click', t.pass, {capture: true});
 	anchor.click();
-	t.is(first && typeof first.destroy, 'function');
-	t.is(second && typeof second.destroy, 'function');
 });
 
 test('should remove an event listener', t => {
@@ -49,10 +44,8 @@ test('should remove an event listener', t => {
 	spy.restore();
 });
 
-test.cb('should use `document` if the element is unspecified', t => {
-	delegate('a', 'click', () => {
-		t.end();
-	});
+test('should use `document` if the element is unspecified', t => {
+	delegate('a', 'click', t.pass);
 
 	anchor.click();
 });

--- a/test.js
+++ b/test.js
@@ -38,7 +38,7 @@ test('should remove an event listener', t => {
 	const spy = sinon.spy(container, 'removeEventListener');
 
 	const delegation = delegate(container, 'a', 'click', () => {});
-	delegation.destroy();
+	delegation.remove();
 
 	t.true(spy.calledOnce);
 	spy.restore();
@@ -54,7 +54,7 @@ test('should remove an event listener the unspecified base (`document`)', t => {
 	const delegation = delegate('a', 'click', () => {});
 	const spy = sinon.spy(document, 'removeEventListener');
 
-	delegation.destroy();
+	delegation.remove();
 	t.true(spy.calledOnce);
 	spy.restore();
 });
@@ -77,7 +77,7 @@ test('should remove the event listeners from all the elements in a base selector
 
 	const delegations = delegate('li', 'a', 'click', () => {});
 	delegations.forEach(delegation => {
-		delegation.destroy();
+		delegation.remove();
 	});
 
 	t.true(spies.every(spy => {
@@ -106,7 +106,7 @@ test('should remove the event listeners from all the elements in a base array', 
 
 	const delegations = delegate(items, 'a', 'click', () => {});
 	delegations.forEach(delegation => {
-		delegation.destroy();
+		delegation.remove();
 	});
 
 	t.true(spies.every(spy => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"target": "es2015"
 	},
 	"files": [
+		"globals.d.ts",
 		"index.ts"
 	]
 }


### PR DESCRIPTION
Fixes https://github.com/bfred-it/delegate-it/issues/9

Instead of manually handling deduplication of all the calls (keeping track of baseElement, selector, callback, options), I'm using [mem](https://github.com/sindresorhus/mem) to wrap the user's callback so there's always 1 unfiltered listener per 1 `callback+selector`. 

However, `mem` can't handle the `callback+selector` pair so I'm also adding [many-keys-map](https://github.com/bfred-it/many-keys-map) as `mem`'s cache handler.

## Major API changes

- Event listeners will be bound to the delegate target, not to the base element (which was weird)
- the TypeScript type `Setup` is no longer exported (it was an internal one anyway)
- `delegate` now returns `{remove: [function]}` instead of `{destroy: [function]}`