### PR TITLE
Revert "Improve single-element detection (#4)"

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -143,8 +143,8 @@ function delegate<TElement extends Element = Element, TEvent extends Event = Eve
 	useCapture?: any
 ): any {
 	// Handle the regular Element usage
-	if (elements instanceof EventTarget) {
-		return _delegate<TElement, TEvent>(elements, selector, type, callback, useCapture);
+	if (typeof (elements as EventTarget).addEventListener === 'function') {
+		return _delegate<TElement, TEvent>(elements as EventTarget, selector, type, callback, useCapture);
 	}
 
 	// Handle Element-less usage, it defaults to global delegation

--- a/test.js
+++ b/test.js
@@ -15,7 +15,6 @@ const {window} = new JSDOM(`
 
 global.Event = window.Event;
 global.Element = window.Element;
-global.EventTarget = window.EventTarget;
 global.document = window.document;
 const container = window.document.querySelector('ul');
 const anchor = window.document.querySelector('a');


### PR DESCRIPTION
This reverts commit 09766e3cec845dadc5dc185eccdd3ec2caaf91f6.

Any other modern feature used in this fork can either be transpiled by Babel or polyfilled for IE 11. But nodes being an instance of the EventTarget constructor cannot be polyfilled. And IE 11 does not expose
EventTarget as a constructor.
Reverting the detection to the method of the EventTarget interface avoids relying on a non-polyfillable API.

This is based on the discussion happening in #8.