### PR TITLE
Allow delegation to any Node, including Shadow DOM roots

### DIFF
--- a/delegate.test.ts
+++ b/delegate.test.ts
@@ -1,5 +1,5 @@
 import {test, vi, expect} from 'vitest';
-import {base, anchor} from './vitest.setup.js';
+import {base, anchor, custom} from './vitest.setup.js';
 import delegate from './delegate.js';
 
 test('should add an event listener', () => {
@@ -102,4 +102,9 @@ test('should deduplicate identical listeners added after `once:true`', () => {
 	expect(spy).toHaveBeenCalledTimes(1); // It should be called on the delegate target
 	anchor.click();
 	expect(spy).toHaveBeenCalledTimes(1); // It should not be called again on the delegate target
+});
+
+test('should allow using a ShadowRoot as delegate target', () => {
+	custom.clickLinks();
+	expect(custom.linksClicked).toBe(2);
 });

--- a/delegate.ts
+++ b/delegate.ts
@@ -55,7 +55,8 @@ function safeClosest(event: Event, selector: string): Element | void {
 		target = target.parentElement;
 	}
 
-	if (target instanceof Element && event.currentTarget instanceof Element) {
+	// currentTarget could be an Element or e.g. a ShadowRoot
+	if (target instanceof Element && event.currentTarget instanceof Node) {
 		// `.closest()` may match ancestors of `currentTarget` but we only need its children
 		const closest = target.closest(selector);
 		if (closest && event.currentTarget.contains(closest)) {

--- a/delegate.ts
+++ b/delegate.ts
@@ -55,7 +55,7 @@ function safeClosest(event: Event, selector: string): Element | void {
 		target = target.parentElement;
 	}
 
-	// currentTarget could be an Element or e.g. a ShadowRoot
+	// The currentTarget could be an Element or e.g. a ShadowRoot
 	if (target instanceof Element && event.currentTarget instanceof Node) {
 		// `.closest()` may match ancestors of `currentTarget` but we only need its children
 		const closest = target.closest(selector);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,22 +1,48 @@
 import {JSDOM} from 'jsdom';
+import delegate from './delegate.js';
 
-const {window} = new JSDOM(`
+const {window} = new JSDOM();
+
+global.Text = window.Text;
+global.Event = window.Event;
+global.Element = window.Element;
+global.HTMLElement = window.HTMLElement;
+global.Node = window.Node;
+global.Document = window.Document;
+global.MouseEvent = window.MouseEvent;
+global.AbortController = window.AbortController;
+global.document = window.document;
+
+class CustomElement extends HTMLElement {
+	public linksClicked = 0;
+
+	connectedCallback(): void {
+		const shadow = this.attachShadow({mode: 'open'});
+		shadow.innerHTML = '<p><a>First link</a></p><p><a>Second link</a></p>';
+
+		delegate('a', 'click', () => this.linksClicked++, {base: shadow});
+	}
+
+	clickLinks(): void {
+		for (const element of this.shadowRoot.querySelectorAll('a')) {
+			element.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+		}
+	}
+}
+
+window.customElements.define('custom-element', CustomElement);
+
+window.document.documentElement.innerHTML = `
 	<ul>
 		<li><a>Item 1</a></li>
 		<li><a>Item 2</a></li>
 		<li><a>Item 3</a></li>
 		<li><a>Item 4</a></li>
 		<li><a>Item 5</a></li>
+		<li><custom-element></custom-element></li>
 	</ul>
-`);
+`;
 
-global.Text = window.Text;
-global.Event = window.Event;
-global.Element = window.Element;
-global.Node = window.Node;
-global.Document = window.Document;
-global.MouseEvent = window.MouseEvent;
-global.AbortController = window.AbortController;
-global.document = window.document;
 export const base = window.document.querySelector('ul')!;
 export const anchor = window.document.querySelector('a')!;
+export const custom = window.document.querySelector<CustomElement>('custom-element')!;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,6 +13,7 @@ const {window} = new JSDOM(`
 global.Text = window.Text;
 global.Event = window.Event;
 global.Element = window.Element;
+global.Node = window.Node;
 global.Document = window.Document;
 global.MouseEvent = window.MouseEvent;
 global.AbortController = window.AbortController;


### PR DESCRIPTION
For use in custom elements with a ShadowRoot, it may be desirable to delegate event handling to the ShadowRoot, as that is the root Node for all elements contained within it.

ShadowRoot is a descendent of Node, and the .contains()-method is defined on Node, such that checking that the currentTarget where the delegated event handler is active is any Node rather than just an Element enables this.